### PR TITLE
Fix issue with reg ex and square brackets

### DIFF
--- a/tuflow/TUFLOW_results.py
+++ b/tuflow/TUFLOW_results.py
@@ -214,7 +214,7 @@ class Timeseries():
 			i += 1
 			a = col[len(prefix)+1:]
 			# strip simulation name - highly unlikely more than one match
-			a = "".join(re.split(r"\[{0}]".format(rSimID), col, re.IGNORECASE)).strip()
+			a = "".join(col.split(r"[{0}]".format(rSimID))).strip()
 			# strip prefix - only take the first occurrence just in case there's more than one match
 			rx = re.search(r"{0}\s".format(prefix), a, re.IGNORECASE)
 			if rx is None:


### PR DESCRIPTION
Think this fixes https://github.com/TUFLOW-Support/QGIS-TUFLOW-Plugin/issues/21
Uses standard split instead of RegEx split, removing issues with square brackets. Quick test suggests this allows time series results to load successfully
Not sure if there are other places where a similar issue will occur with square brackets