### PR TITLE
Fix Python 3.10 error

### DIFF
--- a/tuflow/tuflowqgis_dialog.py
+++ b/tuflow/tuflowqgis_dialog.py
@@ -80,8 +80,8 @@ class tuflowqgis_increment_dialog(QDialog, Ui_tuflowqgis_increment):
 
 		table_width = 414
 
-		self.twTables.setColumnWidth(0, table_width / 2)
-		self.twTables.setColumnWidth(1, table_width / 2)
+		self.twTables.setColumnWidth(0, int(table_width / 2))
+		self.twTables.setColumnWidth(1, int(table_width / 2))
 
 		self.sourcelayer_changed(None, cLayer)
 		if cLayer:


### PR DESCRIPTION
```
TypeError: setColumnWidth(self, int, int): argument 2 has unexpected type 'float' 
Traceback (most recent call last):
  File "/home/pavel/.local/share/QGIS/QGIS3/profiles/default/python/plugins/tuflow/tuflowqgis_menu.py", line 495, in increment_layer
    dialog = tuflowqgis_increment_dialog(self.iface)
  File "/home/pavel/.local/share/QGIS/QGIS3/profiles/default/python/plugins/tuflow/tuflowqgis_dialog.py", line 83, in __init__
    self.twTables.setColumnWidth(0, table_width / 2)
TypeError: setColumnWidth(self, int, int): argument 2 has unexpected type 'float'
```