### PR TITLE
Fix ARR preburst parsing on QGIS 4

### DIFF
--- a/tuflow/ARR2016/preburst.py
+++ b/tuflow/ARR2016/preburst.py
@@ -1,5 +1,6 @@
 import typing
 import logging
+import re
 
 import numpy
 import pandas as pd
@@ -113,18 +114,16 @@ class ArrPreburst:
             elif self.settings.limb_option and limb_data and self.settings.limb_recalc_pb_ratios:
                 self.ratios = self.data.df.copy()
                 for col in self.ratios.columns:
-                    self.ratios[col] = self.ratios[col].str.extract(r'(\d+\.\d+\s+)(\(\d+(?:\.\d*)?\))').iloc[:,
-                                       1].str.replace(r'\(|\)', '', regex=True).astype(float)
+                    self.ratios[col] = self.ratios[col].map(self._parse_ratio_cell)
                 rf_depths = self.get_rainfall_depths(fi)
                 rf_ = rf_depths.reindex_like(self.data.df)
                 self.depths = rf_ * self.ratios
             else:
                 self.ratios = self.data.df.copy()
                 for col in self.depths.columns:
-                    self.depths[col] = self.depths[col].str.replace(r'\(\d+(?:\.\d*)?\)', '', regex=True).astype(float)
+                    self.depths[col] = self.depths[col].map(self._parse_depth_cell)
                 for col in self.ratios.columns:
-                    self.ratios[col] = self.ratios[col].str.extract(r'(\d+\.\d+\s+)(\(\d+(?:\.\d*)?\))').iloc[:,
-                                       1].str.replace(r'\(|\)', '', regex=True).astype(float)
+                    self.ratios[col] = self.ratios[col].map(self._parse_ratio_cell)
         except Exception as e:
             raise Exception('Error loading preburst rainfall data: {0}'.format(e)) from e
 
@@ -133,6 +132,22 @@ class ArrPreburst:
 
     def get_ratios(self, losses):
         return self.ratios.to_numpy()
+
+    @staticmethod
+    def _parse_depth_cell(value: typing.Any) -> float:
+        if pd.isna(value):
+            return numpy.nan
+        text = re.sub(r'\(\d+(?:\.\d*)?\)', '', str(value)).strip()
+        return float(text)
+
+    @staticmethod
+    def _parse_ratio_cell(value: typing.Any) -> float:
+        if pd.isna(value):
+            return numpy.nan
+        match = re.search(r'\((\d+(?:\.\d*)?)\)', str(value))
+        if not match:
+            raise ValueError(f'Could not parse preburst ratio from "{value}"')
+        return float(match.group(1))
 
     def load_storm_initial_loss(self, fi: typing.TextIO) -> bool:
         data = DataBlock(fi, 'LOSSES', True)

--- a/tuflow/test/arr/test_preburst.py
+++ b/tuflow/test/arr/test_preburst.py
@@ -7,6 +7,10 @@ from tuflow.ARR2016.arr_settings import ArrSettings
 
 class TestPreburst(TestCase):
 
+    def test_parse_preburst_cells(self):
+        self.assertEqual(12.3, ArrPreburst._parse_depth_cell('12.3(0.45)'))
+        self.assertEqual(0.45, ArrPreburst._parse_ratio_cell('12.3(0.45)'))
+
     def test_load(self):
         data_file = Path(__file__).parent / 'data' / 'ARR_Web_data_test_catchment.txt'
         pb = ArrPreburst()


### PR DESCRIPTION
## Summary

Fix ARR preburst parsing under QGIS 4 by avoiding pandas Arrow-backed regex string operations that depend on `pyarrow.compute.replace_substring_regex`.

QGIS 4 is bundling a pandas/pyarrow combination where ARR storm generation can fail while loading preburst rainfall data. The failure occurs in `tuflow/ARR2016/preburst.py` when `.str.replace(..., regex=True)` is executed on Arrow string arrays.

This change replaces those Arrow-dependent regex string operations with explicit Python regex parsing for preburst depth and ratio cells, and adds a regression test for the parser helpers.

Experienced this error on multiple computers running Windrows and QGIS 4. This was my workaround to fix it to be able to use the ARR data tool. Not sure if there is a better pandas native method to do this. The script does not appear to be pulling from my local python install so I assume the issue within QGIS / tuflow plugin files.

## Root Cause

`preburst.py` used pandas string accessor regex operations on columns that can be backed by Arrow string arrays in QGIS 4. In this environment, pandas dispatches regex replacement to `pyarrow.compute.replace_substring_regex`, but that attribute is not available in the bundled `pyarrow` build, causing ARR preburst loading to fail.

## Changes

- Replace Arrow-backed `.str.replace(..., regex=True)` parsing in `tuflow/ARR2016/preburst.py` with Python regex helper methods.
- Reuse the same helper methods for both standard preburst parsing and limb ratio recalculation.
- Add a regression test in `tuflow/test/arr/test_preburst.py` covering depth and ratio cell parsing.

## Validation

- Verified the updated parser loads the bundled ARR preburst sample data successfully.
- Verified parsed sample values for both depth and ratio extraction.
- Added regression coverage for the new parser helpers.



## Original Error

```text
ERROR: Unable to load ARR data: Error loading preburst rainfall data: module 'pyarrow.compute' has no attribute 'replace_substring_regex'
Traceback (most recent call last):
  File "C:\Users\<user>\AppData\Roaming\QGIS\QGIS4\profiles\default\python\plugins\tuflow\ARR2016\preburst.py", line 124, in load_depths
    self.depths[col] = self.depths[col].str.replace(r'\(\d+(?:\.\d*)?\)', '', regex=True).astype(float)
  File "C:\PROGRA~1\QGIS40~1.0\apps\Python312\Lib\site-packages\pandas\core\strings\accessor.py", line 142, in wrapper
    return func(self, *args, **kwargs)
  File "C:\PROGRA~1\QGIS40~1.0\apps\Python312\Lib\site-packages\pandas\core\strings\accessor.py", line 1814, in replace
    result = res_output.array._str_replace(
  File "C:\PROGRA~1\QGIS40~1.0\apps\Python312\Lib\site-packages\pandas\core\arrays\string_arrow.py", line 479, in _str_replace
    return ArrowStringArrayMixin._str_replace(
  File "C:\PROGRA~1\QGIS40~1.0\apps\Python312\Lib\site-packages\pandas\core\arrays\_arrow_string_mixins.py", line 242, in _str_replace
    func = pc.replace_substring_regex if regex else pc.replace_substring
AttributeError: module 'pyarrow.compute' has no attribute 'replace_substring_regex'. Did you mean: 'replace_substring'?

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "C:\Users\<user>\AppData\Roaming\QGIS\QGIS4\profiles\default\python\plugins\tuflow\ARR2016\ARR_to_TUFLOW.py", line 935, in ARR_to_TUFLOW
    ARR.load(arr_raw_fname, catchment_area, add_tp=add_tp, point_tp=point_tp_csv, areal_tp=areal_tp_csv,
  File "C:\Users\<user>\AppData\Roaming\QGIS\QGIS4\profiles\default\python\plugins\tuflow\ARR2016\ARR_WebRes.py", line 1009, in load
    self.PreBurst.load(fi, self.settings.preburst_percentile)
  File "C:\Users\<user>\AppData\Roaming\QGIS\QGIS4\profiles\default\python\plugins\tuflow\ARR2016\preburst.py", line 81, in load
    self.load_depths(fi)
  File "C:\Users\<user>\AppData\Roaming\QGIS\QGIS4\profiles\default\python\plugins\tuflow\ARR2016\preburst.py", line 129, in load_depths
    raise Exception('Error loading preburst rainfall data: {0}'.format(e)) from e
Exception: Error loading preburst rainfall data: module 'pyarrow.compute' has no attribute 'replace_substring_regex'





