### PR TITLE
Match layer type when resolving mesh results by name

### DIFF
--- a/tuflow/toc/toc.py
+++ b/tuflow/toc/toc.py
@@ -88,8 +88,11 @@ def tuflowqgis_get_all_layers_for_datasource(datasource, **kwargs):
 def tuflowqgis_find_layer(layer_name, **kwargs):
     search_type = kwargs['search_type'] if 'search_type' in kwargs.keys() else 'name'
     return_type = kwargs['return_type'] if 'return_type' in kwargs else 'layer'
+    layer_class = kwargs['layer_class'] if 'layer_class' in kwargs else None
 
     for name, search_layer in QgsProject.instance().mapLayers().items():
+        if layer_class is not None and not isinstance(search_layer, layer_class):
+            continue  # e.g. a vector layer sharing a name with a mesh result should not be matched
         if search_type.lower() == 'name':
             if search_layer.name() == layer_name:
                 if return_type == 'layer':

--- a/tuflow/tuflowqgis_tuviewer/tuflowqgis_tumenufunctions.py
+++ b/tuflow/tuflowqgis_tuviewer/tuflowqgis_tumenufunctions.py
@@ -1623,7 +1623,9 @@ class TuMenuFunctions():
 		
 		# what happens if there are no mesh layer or more than one active mesh layer
 		if meshIndex is not None and result is not None:
-			meshLayer = tuflowqgis_find_layer(result)
+			meshLayer = tuflowqgis_find_layer(result, layer_class=QgsMeshLayer)
+			if meshLayer is None:  # a non-mesh layer may share the result name
+				return False
 		elif not self.tuView.tuResults.tuResults2D.activeMeshLayers:
 				QMessageBox.information(self.iface.mainWindow(), 'TUFLOW Viewer', 'No Active Result Datasets')
 				return False
@@ -1965,7 +1967,9 @@ class TuMenuFunctions():
 		# get mesh layers (QgsMeshLayer)
 		mLayers = []
 		for mesh in resultMesh:
-			mLayers.append(tuflowqgis_find_layer(mesh))
+			mLayer = tuflowqgis_find_layer(mesh, layer_class=QgsMeshLayer)
+			if mLayer is not None:
+				mLayers.append(mLayer)
 		if not mLayers:
 			return False
 			

--- a/tuflow/tuflowqgis_tuviewer/tuflowqgis_tuplot.py
+++ b/tuflow/tuflowqgis_tuviewer/tuflowqgis_tuplot.py
@@ -4875,7 +4875,7 @@ class TuPlot():
 		meshLayers = findAllMeshLyrs()
 		ref_time_changed = False
 		for ml in meshLayers:
-			ml = tuflowqgis_find_layer(ml)
+			ml = tuflowqgis_find_layer(ml, layer_class=QgsMeshLayer)
 			if ml is None:
 				continue
 			if ml.name() not in results:

--- a/tuflow/tuflowqgis_tuviewer/tuflowqgis_tuproject.py
+++ b/tuflow/tuflowqgis_tuviewer/tuflowqgis_tuproject.py
@@ -485,7 +485,9 @@ class TuProject():
 			for result, rtypeDict in results.items():
 				# result -> 'M03_5m_001'
 				# rtype -> 'Depth' or 'point_ts'
-				layer = tuflowqgis_find_layer(result)
+				layer = tuflowqgis_find_layer(result, layer_class=QgsMeshLayer)
+				if layer is None:
+					continue
 				for rtype, timeDict in rtypeDict.items():
 					#if '_ts' not in rtype and '_lp' not in rtype and '_particles' not in rtype:
 					if TuResults.isMapOutputType(rtype):

--- a/tuflow/tuflowqgis_tuviewer/tuflowqgis_turesults.py
+++ b/tuflow/tuflowqgis_tuviewer/tuflowqgis_turesults.py
@@ -1005,7 +1005,7 @@ class TuResults():
 			pass
 		meshLayers = findAllMeshLyrs()
 		for ml in meshLayers:
-			layer = tuflowqgis_find_layer(ml)
+			layer = tuflowqgis_find_layer(ml, layer_class=QgsMeshLayer)
 			try:
 				layer.repaintRequested.disconnect(self.tuResults2D.repaintRequested)
 			except:
@@ -1027,7 +1027,7 @@ class TuResults():
 		self.tuView.resultSelectionChangeSignal = self.tuView.OpenResults.itemSelectionChanged.connect(
 			lambda: self.tuView.resultsChanged('item clicked'))
 		for ml in meshLayers:
-			layer = tuflowqgis_find_layer(ml)
+			layer = tuflowqgis_find_layer(ml, layer_class=QgsMeshLayer)
 			layer.repaintRequested.connect(self.tuResults2D.repaintRequested)
 
 		# Update viewport with enabled / disabled items
@@ -1880,7 +1880,7 @@ class TuResults():
 
 		meshLayers = findAllMeshLyrs()
 		for ml in meshLayers:
-			layer = tuflowqgis_find_layer(ml)
+			layer = tuflowqgis_find_layer(ml, layer_class=QgsMeshLayer)
 			self.tuResults2D.getResultMetaData(ml, layer, loadRenderStyle=False)
 
 			# update 1D results based on new reference time for mesh layer
@@ -2124,7 +2124,8 @@ class TuResults():
 			tsprocessed = False
 			for restype, resinfo in res.items():
 				if TuResults.isMapOutputType(restype):
-					layer = tuflowqgis_find_layer(resname)
+					# nc grid results are rasters and are handled via tuResultsNcGrid, so only match meshes here
+					layer = tuflowqgis_find_layer(resname, layer_class=QgsMeshLayer)
 					if layer is not None:
 						if not meshprocessed:
 							if qv >= 31300 and not resinfo['hadTemporalProperties']:
@@ -2561,7 +2562,9 @@ class TuResults():
 
 		for lyr in layers:
 			if type(lyr) is str:
-				lyr = tuflowqgis_find_layer(lyr)
+				lyr = tuflowqgis_find_layer(lyr, layer_class=QgsMeshLayer)
+			if lyr is None:
+				continue
 			lyr.setTemporalMatchingMethod(QgsMeshDataProviderTemporalCapabilities.FindClosestDatasetBeforeStartRangeTime)
 
 	@staticmethod
@@ -2570,9 +2573,9 @@ class TuResults():
 
 		for lyr in layers:
 			if type(lyr) is str:
-				lyr = tuflowqgis_find_layer(lyr)
+				lyr = tuflowqgis_find_layer(lyr, layer_class=QgsMeshLayer)
 			if lyr is None:
-				return
+				continue
 			lyr.setTemporalMatchingMethod(QgsMeshDataProviderTemporalCapabilities.FindClosestDatasetFromStartRangeTime)
 
 	def dateToTimeInCombobox(self, inputDate):

--- a/tuflow/tuflowqgis_tuviewer/tuflowqgis_turesults2d.py
+++ b/tuflow/tuflowqgis_tuviewer/tuflowqgis_turesults2d.py
@@ -74,7 +74,7 @@ class TuResults2D():
 			pass
 		meshLayers = findAllMeshLyrs()
 		for ml in meshLayers:
-			layer = tuflowqgis_find_layer(ml)
+			layer = tuflowqgis_find_layer(ml, layer_class=QgsMeshLayer)
 			try:
 				layer.dataProvider().datasetGroupsAdded.disconnect(self.datasetGroupsAdded)
 			except:
@@ -208,7 +208,7 @@ class TuResults2D():
 			lambda: self.tuView.resultsChanged('item clicked'))
 		meshLayers = findAllMeshLyrs()
 		for ml in meshLayers:
-			layer = tuflowqgis_find_layer(ml)
+			layer = tuflowqgis_find_layer(ml, layer_class=QgsMeshLayer)
 			layer.dataProvider().datasetGroupsAdded.connect(self.datasetGroupsAdded)
 			layer.repaintRequested.connect(self.repaintRequested)
 
@@ -233,12 +233,12 @@ class TuResults2D():
 		dirname = os.path.dirname(basepath)
 		
 		# does mesh layer already exist in workspace
-		layer = tuflowqgis_find_layer(basename)
+		layer = tuflowqgis_find_layer(basename, layer_class=QgsMeshLayer)
 		if layer is not None:
 			return layer, basename, True
 		# TUFLOW FV 2dm is named differently so also check provided name does not exist
 		if name is not None:
-			layer_alternative = tuflowqgis_find_layer(name)
+			layer_alternative = tuflowqgis_find_layer(name, layer_class=QgsMeshLayer)
 			if layer_alternative is not None:
 				return layer_alternative, name, True
 		
@@ -911,7 +911,7 @@ class TuResults2D():
 		meshLayers = findAllMeshLyrs()
 		nodes = []
 		for ml in meshLayers:
-			layer = tuflowqgis_find_layer(ml)
+			layer = tuflowqgis_find_layer(ml, layer_class=QgsMeshLayer)
 			node = QgsProject.instance().layerTreeRoot().findLayer(layer.id())
 			if not node:
 				continue
@@ -1254,7 +1254,7 @@ class TuResults2D():
 
 		meshLayers = findAllMeshLyrs()
 		for ml in meshLayers:
-			layer = tuflowqgis_find_layer(ml)
+			layer = tuflowqgis_find_layer(ml, layer_class=QgsMeshLayer)
 			if layer is not None:
 				if layer.datasetGroupCount() == 0:
 					return
@@ -1273,7 +1273,7 @@ class TuResults2D():
 		signalConnected = False
 		meshLayers = findAllMeshLyrs()
 		for ml in meshLayers:
-			layer = tuflowqgis_find_layer(ml)
+			layer = tuflowqgis_find_layer(ml, layer_class=QgsMeshLayer)
 			try:
 				layer.repaintRequested.disconnect(self.repaintRequested)
 				signalConnected = True
@@ -1302,7 +1302,7 @@ class TuResults2D():
 		# for QGIS 3.18.1 hack to force mesh to show
 		meshLayers = findAllMeshLyrs()
 		for ml in meshLayers:
-			layer = tuflowqgis_find_layer(ml)
+			layer = tuflowqgis_find_layer(ml, layer_class=QgsMeshLayer)
 			if layer in self.activeMeshLayers:
 				rs = layer.rendererSettings()
 				rsMesh = rs.nativeMeshSettings()
@@ -1319,7 +1319,7 @@ class TuResults2D():
 		if signalConnected:
 			meshLayers = findAllMeshLyrs()
 			for ml in meshLayers:
-				layer = tuflowqgis_find_layer(ml)
+				layer = tuflowqgis_find_layer(ml, layer_class=QgsMeshLayer)
 				layer.repaintRequested.connect(self.repaintRequested)
 
 	def applyScalarRenderSettings(self, layer, datasetGroupIndex, file, type, save_type='xml'):
@@ -1643,7 +1643,7 @@ class TuResults2D():
 			pass
 		meshLayers = findAllMeshLyrs()
 		for ml in meshLayers:
-			layer = tuflowqgis_find_layer(ml)
+			layer = tuflowqgis_find_layer(ml, layer_class=QgsMeshLayer)
 			try:
 				layer.dataProvider().datasetGroupsAdded.disconnect(self.datasetGroupsAdded)
 			except:
@@ -1654,7 +1654,7 @@ class TuResults2D():
 				pass
 
 		for res in self.results2d:
-			layer = tuflowqgis_find_layer(res)
+			layer = tuflowqgis_find_layer(res, layer_class=QgsMeshLayer)
 			if layer is None:
 				continue
 			node = QgsProject.instance().layerTreeRoot().findLayer(layer.id())
@@ -1671,7 +1671,7 @@ class TuResults2D():
 			lambda: self.tuView.resultsChanged('item clicked'))
 		meshLayers = findAllMeshLyrs()
 		for ml in meshLayers:
-			layer = tuflowqgis_find_layer(ml)
+			layer = tuflowqgis_find_layer(ml, layer_class=QgsMeshLayer)
 			layer.dataProvider().datasetGroupsAdded.connect(self.datasetGroupsAdded)
 			layer.repaintRequested.connect(self.repaintRequested)
 

--- a/tuflow/tuflowqgis_tuviewer/tuflowqgis_tuview.py
+++ b/tuflow/tuflowqgis_tuviewer/tuflowqgis_tuview.py
@@ -1010,7 +1010,7 @@ class TuView(QDockWidget, Ui_Tuplot):
 			if completely_remove:
 				meshLayers = findAllMeshLyrs()
 				for ml in meshLayers:
-					layer = tuflowqgis_find_layer(ml)
+					layer = tuflowqgis_find_layer(ml, layer_class=QgsMeshLayer)
 					try:
 						layer.dataProvider().datasetGroupsAdded.disconnect(self.datasetGroupsAdded)
 					except:


### PR DESCRIPTION
AI used to help write and solve the issue

Fixes https://github.com/TUFLOW-Support/QGIS-TUFLOW-Plugin/issues/50

tuflowqgis_find_layer() matched on layer name alone, so any layer sharing a name with a result could be returned to callers that required a QgsMeshLayer.

Where the name matched a vector layer, loadMeshLayer() reported the mesh as pre-existing and passed the vector layer to loadDataGroup(), which failed on datasetGroupCount(). The same collision broke project save, where processMeshStyles() resolves stored result names and saveDefaultStyleScalar() called rendererSettings() on the result.

Several call sites also round-tripped through findAllMeshLyrs(), which filters on QgsMeshLayer but returns names, discarding the type guarantee it had just established.

Add an optional layer_class keyword to tuflowqgis_find_layer() and pass QgsMeshLayer where a mesh is required, with None guards where the stricter lookup can now miss. Call sites that legitimately handle 1D, NetCDF grid and particle results are left type-agnostic.